### PR TITLE
ENH: adds metautils.abc

### DIFF
--- a/metautils/abc.py
+++ b/metautils/abc.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+
+from abc import ABCMeta
+
+from metautils import T
+
+
+class ABCMetaTemplate(T, ABCMeta):
+    """
+    A helper for creating ABC versions of other metaclasses. This creates a
+    class with an empty body whose mro is:
+    ``(subclass, T, ABCMeta, type, object)``
+    """

--- a/metautils/template.py
+++ b/metautils/template.py
@@ -23,7 +23,6 @@ class TemplateBase(object):
     """
     A marker for `Template` types.
     """
-    pass
 
 
 class _TemplateMeta(type):
@@ -61,19 +60,40 @@ class _TemplateMeta(type):
 
         class Template(TemplateBase):
             """
-            A callable that takes a base metaclass and returns a new metaclass
-            that is a composition of this metaclass template and a base
-            metaclass.
+            A callable that takes a base class and returns a new class
+            that is a composition of this class template and a base class.
+
+            Parameters
+            ----------
+            base : type
+                The class to create a subclass of.
+
+            Returns
+            -------
+            subclass : type
+                A subclass of ``base`` with the body of this template.
             """
+            # Copy the docstring from the template if provided.
+            __doc__ = dict_.get('__doc__', __doc__)
             __slots__ = ()
 
             def __call__(self, base=type, adjust_name=True):
                 """
-                Constructs a new metaclass that is the composition of this
-                metaclass template and a base metaclass.
+                Constructs a new class that is the composition of this
+                class template and a base class.
 
-                If `adjust_name` is truthy, the name of the base class will be
-                prepended with the name of the new class.
+                Parameters
+                ----------
+                base : type, optional
+                    The class to create a subclass of.
+                adjust_name : bool, optional
+                    Should the name of the resulting subclass be adjusted
+                    to include the name of the base class.
+
+                Returns
+                -------
+                subclass : type
+                    A subclass of ``base`` with the body of this template.
                 """
                 dict_cpy = dict_.copy()  # We could potentially mutate this.
                 inner_bases = (base,) + bases
@@ -132,7 +152,6 @@ class _TWithArgs(object):
     Marker to indicate that this is a template argument that is holding the
     arguments.
     """
-    pass
 
 
 def T_new(cls, **kwargs):
@@ -227,4 +246,3 @@ class templated(methodbox):
     Marker to indicate that the method should be passed `T` under the
     name: `T_`
     """
-    pass

--- a/metautils/tests/_test_abc_py2.py
+++ b/metautils/tests/_test_abc_py2.py
@@ -1,0 +1,13 @@
+from abc import abstractmethod
+from metautils.abc import ABCMetaTemplate
+
+
+def make_class(self):
+    class C(object):
+        __metaclass__ = ABCMetaTemplate(self.M)
+
+        @abstractmethod
+        def abstract_method(self):
+            pass
+
+    return C

--- a/metautils/tests/_test_abc_py3.py
+++ b/metautils/tests/_test_abc_py3.py
@@ -1,0 +1,11 @@
+from abc import abstractmethod
+from metautils.abc import ABCMetaTemplate
+
+
+def make_class(self):
+    class C(metaclass=ABCMetaTemplate(self.M)):
+        @abstractmethod
+        def abstract_method(self):
+            pass
+
+    return C

--- a/metautils/tests/test_abc.py
+++ b/metautils/tests/test_abc.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+
+from metautils.compat import PY3
+
+
+class ABCMetaTemplateTestCase(TestCase):
+    class M(type):
+        def __new__(mcls, name, bases, dict_):
+            dict_['M'] = True
+            return super(ABCMetaTemplateTestCase.M, mcls).__new__(
+                mcls,
+                name,
+                bases,
+                dict_,
+            )
+
+    if PY3:
+        from ._test_abc_py3 import make_class
+    else:
+        from ._test_abc_py2 import make_class  # noqa
+
+    def test_abc(self):
+        with self.assertRaises(TypeError) as e:
+            self.make_class()()
+
+        self.assertIn('abstract_method', str(e.exception))

--- a/metautils/tests/test_template.py
+++ b/metautils/tests/test_template.py
@@ -25,9 +25,11 @@ class MetaFactoryTestCase(TestCase):
         Tests that subclassing T returns a template.
         """
         class template(T):
+            """template doc"""
             pass
 
         self.assertIsInstance(template, TemplateBase)
+        self.assertEqual(template.__doc__, 'template doc')
 
 
 if PY2:


### PR DESCRIPTION
This module makes it easy to quickly create ABCMeta mixed in versions of
a nother metaclass.
